### PR TITLE
Configura projeto inicial com React, Tailwind e Lucide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.dist
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dist
+

--- a/portDavid/package.json
+++ b/portDavid/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "portdavid",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "lucide-react": "^0.344.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "react-scripts": "5.0.1"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/portDavid/postcss.config.js
+++ b/portDavid/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/portDavid/public/index.html
+++ b/portDavid/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfólio de David</title>
+  </head>
+  <body class="font-sans bg-gray-900">
+    <div id="root"></div>
+  </body>
+</html>

--- a/portDavid/src/App.js
+++ b/portDavid/src/App.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Smile } from 'lucide-react';
+
+function App() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
+      <Smile className="w-12 h-12 text-white" />
+      <h1 className="text-2xl font-bold text-white">Bem-vindo ao Portfólio de David</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/portDavid/src/index.css
+++ b/portDavid/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-900 text-white;
+}

--- a/portDavid/src/index.js
+++ b/portDavid/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/portDavid/tailwind.config.js
+++ b/portDavid/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./public/index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Resumo
- Estrutura inicial do projeto React com configuração do Tailwind CSS
- Inclusão do ícone Smile via Lucide React
- Definição de tema escuro padrão com tipografia padrão

## Testes
- `npm install` *(falhou: 403 Forbidden ao buscar dependências)*
- `npm test` *(falhou: react-scripts não encontrado devido à falha na instalação)*

------
https://chatgpt.com/codex/tasks/task_b_68a50b5b0f0c8322a8c9486229adcdd1