### PR TITLE
feat: modo claro/escuro e blog

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "lucide-react": "^0.344.0",
-    "animejs": "^3.2.1"
+    "animejs": "^3.2.1",
+    "framer-motion": "^11.0.0",
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#EF4444"/>
+  <text x="32" y="44" text-anchor="middle" font-size="40" font-family="Arial, Helvetica, sans-serif" fill="white">D</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Portifolio</title>
   </head>
   <body>

--- a/public/posts/primeiro.md
+++ b/public/posts/primeiro.md
@@ -1,0 +1,3 @@
+# Meu Primeiro Post
+
+Este é um **exemplo** de artigo escrito em Markdown. Você pode adicionar código, listas e muito mais.

--- a/public/posts/segundo.md
+++ b/public/posts/segundo.md
@@ -1,0 +1,3 @@
+# Segundo Post
+
+Outro texto para demonstrar a renderização de múltiplos arquivos Markdown.

--- a/src/App.js
+++ b/src/App.js
@@ -7,10 +7,11 @@ import Habilidades from "./components/Habilidades";
 import Experiencia from "./components/Experiencia";
 import Contato from "./components/Contato";
 import ParticleBackground from "./components/ParticleBackground";
+import Blog from "./components/Blog";
 
 function App() {
   return (
-    <div className="font-sans relative">
+    <div className="font-sans relative bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <ParticleBackground />
       <Navbar />
       <main className="pt-16 space-y-24">
@@ -19,6 +20,7 @@ function App() {
         <Projetos />
         <Habilidades />
         <Experiencia />
+        <Blog />
         <Contato />
       </main>
     </div>

--- a/src/components/Blog.js
+++ b/src/components/Blog.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { BookOpen } from 'lucide-react';
+import { posts } from '../posts';
+import { motion } from 'framer-motion';
+
+function Blog() {
+  const [contents, setContents] = useState([]);
+
+  useEffect(() => {
+    Promise.all(posts.map(p => fetch(p.file).then(res => res.text()))).then(setContents);
+  }, []);
+
+  return (
+    <section id="blog" className="min-h-screen flex flex-col items-center justify-center gap-8">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
+        <BookOpen /> Artigos
+      </h1>
+      <div className="space-y-10 w-full max-w-3xl">
+        {contents.map((content, idx) => (
+          <motion.article
+            key={posts[idx].slug}
+            className="p-4 rounded bg-gray-100 dark:bg-gray-800"
+            whileHover={{ scale: 1.02 }}
+          >
+            <h2 className="text-2xl font-semibold mb-2">{posts[idx].title}</h2>
+            <ReactMarkdown>{content}</ReactMarkdown>
+          </motion.article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Blog;

--- a/src/components/Contato.js
+++ b/src/components/Contato.js
@@ -1,11 +1,13 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { Mail } from "lucide-react";
 import anime from "animejs";
 import useFadeIn from "../hooks/useFadeIn";
+import { motion } from "framer-motion";
 
 function Contato() {
   const ref = useFadeIn();
   const btnRef = useRef(null);
+  const [status, setStatus] = useState(null);
 
   const handleFocus = (e) => {
     anime({ targets: e.target, scale: 1.05, duration: 200 });
@@ -15,7 +17,7 @@ function Contato() {
     anime({ targets: e.target, scale: 1, duration: 200 });
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     anime({
       targets: btnRef.current,
@@ -23,6 +25,23 @@ function Contato() {
       duration: 600,
       easing: "easeOutElastic(1, .5)",
     });
+    const form = e.target;
+    const data = new FormData(form);
+    try {
+      const res = await fetch("https://formspree.io/f/seuID", {
+        method: "POST",
+        body: data,
+        headers: { Accept: "application/json" },
+      });
+      if (res.ok) {
+        setStatus("Mensagem enviada!");
+        form.reset();
+      } else {
+        setStatus("Erro ao enviar.");
+      }
+    } catch (err) {
+      setStatus("Erro ao enviar.");
+    }
   };
 
   return (
@@ -37,31 +56,40 @@ function Contato() {
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-full max-w-md">
         <input
           type="text"
+          name="name"
           placeholder="Nome"
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className="p-2 rounded bg-gray-800"
+          required
+          className="p-2 rounded bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100"
         />
         <input
           type="email"
+          name="email"
           placeholder="Email"
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className="p-2 rounded bg-gray-800"
+          required
+          className="p-2 rounded bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100"
         />
         <textarea
+          name="message"
           placeholder="Mensagem"
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className="p-2 rounded bg-gray-800 h-32"
+          required
+          className="p-2 rounded bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 h-32"
         ></textarea>
-        <button
+        <motion.button
           ref={btnRef}
           type="submit"
           className="self-center px-6 py-3 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
         >
           Enviar
-        </button>
+        </motion.button>
+        {status && <p className="text-center">{status}</p>}
       </form>
     </section>
   );

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { Home as HomeIcon } from "lucide-react";
 import anime from "animejs";
 import useFadeIn from "../hooks/useFadeIn";
+import { motion } from "framer-motion";
 
 function Home() {
   const ref = useFadeIn();
@@ -53,28 +54,34 @@ function Home() {
           <span ref={textRef}></span>
         </h1>
         <div className="flex justify-center gap-4">
-          <a
+          <motion.a
             href="https://github.com/octocat"
             target="_blank"
             rel="noopener noreferrer"
             className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
           >
             GitHub
-          </a>
-          <a
+          </motion.a>
+          <motion.a
             href="https://linkedin.com/in/octocat"
             target="_blank"
             rel="noopener noreferrer"
             className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
           >
             LinkedIn
-          </a>
-          <a
+          </motion.a>
+          <motion.a
             href="#sobre"
             className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
           >
             Saiba Mais
-          </a>
+          </motion.a>
         </div>
       </div>
       <span

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { motion } from "framer-motion";
 
 const secoes = [
   { id: "inicio", rotulo: "Início" },
@@ -6,23 +8,44 @@ const secoes = [
   { id: "projetos", rotulo: "Projetos" },
   { id: "habilidades", rotulo: "Habilidades" },
   { id: "experiencia", rotulo: "Experiência/Formação" },
+  { id: "blog", rotulo: "Blog" },
   { id: "contato", rotulo: "Contato" },
 ];
 
 function Navbar() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [dark]);
+
   return (
-    <nav className="fixed top-0 left-0 w-full bg-gray-900 text-gray-100 shadow z-10">
-      <ul className="flex gap-4 p-4 justify-center">
+    <nav className="fixed top-0 left-0 w-full bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow z-10">
+      <ul className="flex gap-4 p-4 justify-center items-center">
         {secoes.map((secao) => (
-          <li key={secao.id}>
+          <motion.li key={secao.id} whileHover={{ scale: 1.1 }}>
             <a
               href={`#${secao.id}`}
               className="hover:text-red-500 transition-colors"
             >
               {secao.rotulo}
             </a>
-          </li>
+          </motion.li>
         ))}
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => setDark(!dark)}
+          className="ml-4"
+          aria-label="Alternar tema"
+        >
+          {dark ? <Sun /> : <Moon />}
+        </motion.button>
       </ul>
     </nav>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -8,5 +8,5 @@ html {
 }
 
 body {
-  @apply bg-gray-900 text-gray-100;
+  @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100;
 }

--- a/src/posts.js
+++ b/src/posts.js
@@ -1,0 +1,4 @@
+export const posts = [
+  { title: 'Meu Primeiro Post', slug: 'primeiro', file: '/posts/primeiro.md' },
+  { title: 'Segundo Post', slug: 'segundo', file: '/posts/segundo.md' }
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./public/index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Resumo
- adiciona suporte a tema claro/escuro com botão de alternância
- cria seção de artigos com renderização de Markdown
- integra formulário de contato ao Formspree
- inclui favicon com iniciais e microinterações com Framer Motion

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a51ae11160832298110e54e01f5a86