### PR TITLE
Transformar Navbar em drawer e melhorar Home

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -22,7 +22,7 @@ function Home() {
         rotateZ: [15, 0],
         easing: "easeOutExpo",
         duration: 750,
-        delay: anime.stagger(50),
+        delay: anime.stagger(30),
       });
 
     anime({
@@ -43,12 +43,12 @@ function Home() {
       ref={ref}
       className="relative min-h-screen flex items-center justify-center overflow-hidden px-4"
     >
-      <div className="text-center z-10 space-y-6">
-        <h1 className="text-3xl md:text-4xl font-bold flex items-center justify-center gap-2 text-red-500">
+      <div className="text-center z-10 space-y-4 sm:space-y-6">
+        <h1 className="text-3xl md:text-5xl font-bold flex items-center justify-center gap-2 text-red-500">
           <HomeIcon />
           <span ref={textRef}></span>
         </h1>
-        <div className="flex flex-col sm:flex-row justify-center gap-4">
+        <div className="flex flex-col md:flex-row justify-center gap-4">
           <motion.a
             href="https://github.com/Pexe"
             target="_blank"
@@ -69,22 +69,14 @@ function Home() {
           >
             Instagram
           </motion.a>
-          <motion.a
-            href="#sobre"
-            className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            Saiba Mais
-          </motion.a>
         </div>
       </div>
       <span
-        className="shape absolute w-16 h-16 md:w-24 md:h-24 bg-red-600 opacity-20 left-10 top-10"
+        className="shape absolute w-16 h-16 md:w-24 md:h-24 bg-red-600 opacity-10 md:opacity-20 left-10 top-10"
         style={{ borderRadius: "20%" }}
       ></span>
       <span
-        className="shape absolute w-20 h-20 md:w-32 md:h-32 bg-red-600 opacity-20 right-10 bottom-10"
+        className="shape absolute w-20 h-20 md:w-32 md:h-32 bg-red-600 opacity-10 md:opacity-20 right-10 bottom-10"
         style={{ borderRadius: "20%" }}
       ></span>
     </section>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X } from "lucide-react";
 
 const secoes = [
@@ -15,24 +15,18 @@ function Navbar() {
   const [aberto, setAberto] = useState(false);
 
   return (
-    <nav className="fixed top-0 left-0 w-full bg-gray-900 text-gray-100 shadow z-10">
-      <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
+    <nav className="fixed top-0 left-0 w-full bg-gray-900 z-50 text-gray-100 shadow">
+      <div className="max-w-5xl mx-auto flex items-center justify-end p-4">
         <button
           className="md:hidden"
-          onClick={() => setAberto(!aberto)}
-          aria-label="Alternar menu"
+          onClick={() => setAberto(true)}
+          aria-label="Abrir menu"
         >
-          {aberto ? <X /> : <Menu />}
+          <Menu />
         </button>
-        <ul
-          className={`${aberto ? "flex" : "hidden"} flex-col md:flex md:flex-row gap-4 md:justify-center md:items-center`}
-        >
+        <ul className="hidden md:flex md:flex-row gap-4 md:justify-center md:items-center">
           {secoes.map((secao) => (
-            <motion.li
-              key={secao.id}
-              whileHover={{ scale: 1.1 }}
-              onClick={() => setAberto(false)}
-            >
+            <motion.li key={secao.id} whileHover={{ scale: 1.1 }}>
               <a
                 href={`#${secao.id}`}
                 className="hover:text-red-500 transition-colors"
@@ -43,6 +37,49 @@ function Navbar() {
           ))}
         </ul>
       </div>
+      <AnimatePresence>
+        {aberto && (
+          <>
+            <motion.div
+              className="fixed inset-0 bg-black/50 z-40"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setAberto(false)}
+            />
+            <motion.div
+              className="fixed top-0 left-0 h-full w-64 bg-gray-900 shadow z-50 p-6"
+              initial={{ x: "-100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "-100%" }}
+            >
+              <button
+                className="mb-8"
+                onClick={() => setAberto(false)}
+                aria-label="Fechar menu"
+              >
+                <X />
+              </button>
+              <ul className="flex flex-col gap-4">
+                {secoes.map((secao) => (
+                  <motion.li
+                    key={secao.id}
+                    whileHover={{ scale: 1.1 }}
+                    onClick={() => setAberto(false)}
+                  >
+                    <a
+                      href={`#${secao.id}`}
+                      className="hover:text-red-500 transition-colors"
+                    >
+                      {secao.rotulo}
+                    </a>
+                  </motion.li>
+                ))}
+              </ul>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </nav>
   );
 }


### PR DESCRIPTION
## Resumo
- Substitui o menu mobile por um drawer deslizante com overlay escuro
- Ajusta tipografia e espaçamentos da Home para telas menores
- Remove botão "Saiba Mais" e organiza links de GitHub e Instagram

