### PR TITLE
Reverte tema vermelho agressivo

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import ParticleBackground from "./components/ParticleBackground";
 
 function App() {
   return (
-    <div className="font-sans relative bg-black text-white">
+    <div className="font-sans relative bg-gray-900 text-gray-100">
       <ParticleBackground />
       <Navbar />
       <main className="pt-16 space-y-12">

--- a/src/components/Contato.js
+++ b/src/components/Contato.js
@@ -48,9 +48,9 @@ function Contato() {
     <section
       id="contato"
       ref={ref}
-      className="py-20 flex flex-col items-center justify-center gap-6 border-b-4 border-red-700"
+      className="py-20 flex flex-col items-center justify-center gap-6"
     >
-      <h1 className="text-4xl font-extrabold flex items-center gap-2 text-red-600">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
         <Mail /> Contato
       </h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-full max-w-md">
@@ -61,7 +61,7 @@ function Contato() {
           onFocus={handleFocus}
           onBlur={handleBlur}
           required
-          className="p-2 rounded bg-black border-2 border-red-700 text-white focus:outline-none focus:ring-2 focus:ring-red-700"
+          className="p-2 rounded bg-gray-800 text-gray-100"
         />
         <input
           type="email"
@@ -70,7 +70,7 @@ function Contato() {
           onFocus={handleFocus}
           onBlur={handleBlur}
           required
-          className="p-2 rounded bg-black border-2 border-red-700 text-white focus:outline-none focus:ring-2 focus:ring-red-700"
+          className="p-2 rounded bg-gray-800 text-gray-100"
         />
         <textarea
           name="message"
@@ -78,12 +78,12 @@ function Contato() {
           onFocus={handleFocus}
           onBlur={handleBlur}
           required
-          className="p-2 rounded bg-black border-2 border-red-700 text-white h-32 focus:outline-none focus:ring-2 focus:ring-red-700"
+          className="p-2 rounded bg-gray-800 text-gray-100 h-32"
         ></textarea>
         <motion.button
           ref={btnRef}
           type="submit"
-          className="self-center px-6 py-3 font-bold text-black rounded bg-red-700 border-2 border-red-700 hover:bg-white hover:text-red-700"
+          className="self-center px-6 py-3 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >

--- a/src/components/Experiencia.js
+++ b/src/components/Experiencia.js
@@ -19,25 +19,25 @@ function Experiencia() {
     <section
       id="experiencia"
       ref={ref}
-      className="py-20 flex flex-col items-center justify-center gap-8 border-b-4 border-red-700"
+      className="py-20 flex flex-col items-center justify-center gap-8"
     >
-      <h1 className="text-4xl font-extrabold flex items-center gap-2 text-red-600">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
         <Briefcase /> Trajetória
       </h1>
       <div className="flex flex-col md:flex-row gap-10">
         <div>
-          <h2 className="text-xl font-semibold mb-4 text-red-600">Experiência</h2>
+          <h2 className="text-xl font-semibold mb-4">Experiência</h2>
           <div className="relative pl-6">
-            <div className="absolute left-0 top-0 h-full border-l-2 border-red-700"></div>
+            <div className="absolute left-0 top-0 h-full border-l-2 border-red-600"></div>
             <div className="timeline-item mb-6">
               <h3>Em busca da primeira oportunidade de trabalho</h3>
             </div>
           </div>
         </div>
         <div>
-          <h2 className="text-xl font-semibold mb-4 text-red-600">Formação</h2>
+          <h2 className="text-xl font-semibold mb-4">Formação</h2>
           <div className="relative pl-6">
-            <div className="absolute left-0 top-0 h-full border-l-2 border-red-700"></div>
+            <div className="absolute left-0 top-0 h-full border-l-2 border-red-600"></div>
             <div className="timeline-item mb-6">
               <h3>Engenharia de Software - UFAM (2025 - Presente)</h3>
             </div>

--- a/src/components/Habilidades.js
+++ b/src/components/Habilidades.js
@@ -36,13 +36,13 @@ function Habilidades() {
   }, []);
 
   return (
-    <section id="habilidades" ref={ref} className="py-20 flex flex-col items-center justify-center gap-8 border-b-4 border-red-700">
-      <h1 className="text-4xl font-extrabold flex items-center gap-2 text-red-600">
+    <section id="habilidades" ref={ref} className="py-20 flex flex-col items-center justify-center gap-8">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
         <BarChart2 /> Habilidades
       </h1>
       <div className="flex flex-wrap gap-2 justify-center w-2/3">
         {tecnologias.map((tec) => (
-          <span key={tec} className="tag px-3 py-1 bg-black border border-red-700 rounded text-sm">
+          <span key={tec} className="tag px-3 py-1 bg-gray-800 rounded text-sm">
             {tec}
           </span>
         ))}
@@ -54,10 +54,10 @@ function Habilidades() {
               <span>{lang.nome}</span>
               <span ref={(el) => (percentRef.current[i] = el)}>0%</span>
             </div>
-            <div className="w-full bg-black border border-red-700 h-4 rounded">
+            <div className="w-full bg-gray-700 h-4 rounded">
               <div
                 ref={(el) => (barrasRef.current[i] = el)}
-                className="h-4 bg-red-700"
+                className="h-4 bg-red-600 rounded"
                 style={{ width: 0 }}
               ></div>
             </div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -41,10 +41,10 @@ function Home() {
     <section
       id="inicio"
       ref={ref}
-      className="relative min-h-screen flex items-center justify-center overflow-hidden px-4 border-b-4 border-red-700"
+      className="relative min-h-screen flex items-center justify-center overflow-hidden px-4"
     >
       <div className="text-center z-10 space-y-4 sm:space-y-6">
-        <h1 className="text-3xl md:text-5xl font-extrabold flex items-center justify-center gap-2 text-red-600">
+        <h1 className="text-3xl md:text-5xl font-bold flex items-center justify-center gap-2 text-red-500">
           <HomeIcon />
           <span ref={textRef}></span>
         </h1>
@@ -53,7 +53,7 @@ function Home() {
             href="https://github.com/Pexe"
             target="_blank"
             rel="noopener noreferrer"
-            className="px-4 py-2 font-bold text-black rounded bg-red-700 border-2 border-red-700 hover:bg-white hover:text-red-700"
+            className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
           >
@@ -63,7 +63,7 @@ function Home() {
             href="https://instagram.com/David.devloli"
             target="_blank"
             rel="noopener noreferrer"
-            className="px-4 py-2 font-bold text-black rounded bg-red-700 border-2 border-red-700 hover:bg-white hover:text-red-700"
+            className="px-4 py-2 text-white rounded bg-gradient-to-r from-red-600 to-orange-500"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
           >

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -15,10 +15,10 @@ function Navbar() {
   const [aberto, setAberto] = useState(false);
 
   return (
-    <nav className="fixed top-0 left-0 w-full bg-black z-50 text-white border-b-4 border-red-700 shadow-[0_0_10px_#ff0000]">
+    <nav className="fixed top-0 left-0 w-full bg-gray-900 z-50 text-gray-100 shadow">
       <div className="max-w-5xl mx-auto flex items-center justify-end p-4">
         <button
-          className="md:hidden text-red-600"
+          className="md:hidden"
           onClick={() => setAberto(true)}
           aria-label="Abrir menu"
         >
@@ -29,7 +29,7 @@ function Navbar() {
             <motion.li key={secao.id} whileHover={{ scale: 1.1 }}>
               <a
                 href={`#${secao.id}`}
-                className="px-3 py-1 rounded hover:bg-red-700 hover:text-black transition-colors"
+                className="hover:text-red-500 transition-colors"
               >
                 {secao.rotulo}
               </a>
@@ -48,13 +48,13 @@ function Navbar() {
               onClick={() => setAberto(false)}
             />
             <motion.div
-              className="fixed top-0 left-0 h-full w-64 bg-black border-r-4 border-red-700 shadow z-50 p-6"
+              className="fixed top-0 left-0 h-full w-64 bg-gray-900 shadow z-50 p-6"
               initial={{ x: "-100%" }}
               animate={{ x: 0 }}
               exit={{ x: "-100%" }}
             >
               <button
-                className="mb-8 text-red-600"
+                className="mb-8"
                 onClick={() => setAberto(false)}
                 aria-label="Fechar menu"
               >
@@ -69,7 +69,7 @@ function Navbar() {
                   >
                     <a
                       href={`#${secao.id}`}
-                      className="px-2 py-1 rounded hover:bg-red-700 hover:text-black transition-colors"
+                      className="hover:text-red-500 transition-colors"
                     >
                       {secao.rotulo}
                     </a>

--- a/src/components/ParticleBackground.js
+++ b/src/components/ParticleBackground.js
@@ -25,7 +25,7 @@ export default function ParticleBackground() {
         p.y += p.vy;
         if (p.x < 0 || p.x > width) p.vx *= -1;
         if (p.y < 0 || p.y > height) p.vy *= -1;
-        ctx.fillStyle = '#ff0000';
+        ctx.fillStyle = '#f87171';
         ctx.beginPath();
         ctx.arc(p.x, p.y, 2, 0, Math.PI * 2);
         ctx.fill();
@@ -36,7 +36,7 @@ export default function ParticleBackground() {
           const b = particles[j];
           const dist = Math.hypot(a.x - b.x, a.y - b.y);
           if (dist < 120) {
-            ctx.strokeStyle = `rgba(255,0,0,${1 - dist / 120})`;
+            ctx.strokeStyle = `rgba(248,113,113,${1 - dist / 120})`;
             ctx.beginPath();
             ctx.moveTo(a.x, a.y);
             ctx.lineTo(b.x, b.y);

--- a/src/components/Projetos.js
+++ b/src/components/Projetos.js
@@ -61,8 +61,8 @@ function Projetos() {
   }, []);
 
   return (
-    <section id="projetos" ref={ref} className="py-20 flex flex-col items-center justify-center gap-8 border-b-4 border-red-700">
-      <h1 className="text-4xl font-extrabold flex items-center gap-2 text-red-600">
+    <section id="projetos" ref={ref} className="py-20 flex flex-col items-center justify-center gap-8">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
         <Folder /> Projetos (<span ref={countRef}></span>)
       </h1>
       {projetos.length === 0 ? (
@@ -74,13 +74,13 @@ function Projetos() {
             {projetos.map((proj) => (
               <div
                 key={proj.nome}
-                className="projeto-card bg-black border-2 border-red-700 p-4 rounded shadow"
+                className="projeto-card bg-gray-800 p-4 rounded shadow"
               >
-                <h2 className="text-xl mb-2 text-red-600">{proj.nome}</h2>
+                <h2 className="text-xl mb-2">{proj.nome}</h2>
                 <p className="mb-4 text-sm">{proj.sobre}</p>
                 <a
                   href={proj.link}
-                  className="inline-flex items-center gap-2 px-4 py-2 font-bold text-black rounded bg-red-700 border-2 border-red-700 hover:bg-white hover:text-red-700"
+                  className="inline-flex items-center gap-2 text-white px-4 py-2 rounded bg-gradient-to-r from-red-600 to-orange-500"
                 >
                   <ExternalLink size={16} /> Ver
                 </a>

--- a/src/components/Sobre.js
+++ b/src/components/Sobre.js
@@ -30,16 +30,16 @@ function Sobre() {
     <section
       id="sobre"
       ref={ref}
-      className="py-20 flex flex-col items-center justify-center gap-8 border-b-4 border-red-700"
+      className="py-20 flex flex-col items-center justify-center gap-8"
     >
-      <h1 className="text-4xl font-extrabold flex items-center gap-2 text-red-600">
+      <h1 className="text-4xl font-bold flex items-center gap-2 text-red-500">
         <User /> Sobre Mim
       </h1>
       <div className="flex flex-col md:flex-row items-center gap-8">
         {avatar && (
-          <img src={avatar} alt="Foto de Pexe" className="w-40 h-40 rounded-full border-4 border-red-700" />
+          <img src={avatar} alt="Foto de Pexe" className="w-40 h-40 rounded-full" />
         )}
-        <p ref={textRef} className="max-w-md text-center md:text-left leading-relaxed">
+        <p ref={textRef} className="max-w-md text-center md:text-left">
           Olá! Sou David Henrique, estudante de Engenharia de Software e desenvolvedor backend.
           Cursando Engenharia de Software na Universidade Federal do Amazonas (UFAM) desde 2025
           e em busca da primeira oportunidade de trabalho.

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Anton&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -10,15 +8,5 @@ html {
 }
 
 body {
-  @apply bg-black text-white tracking-wide;
-}
-
-@layer base {
-  h1,
-  h2,
-  h3,
-  h4 {
-    font-family: 'Anton', sans-serif;
-    @apply uppercase tracking-widest;
-  }
+  @apply bg-gray-900 text-gray-100;
 }


### PR DESCRIPTION
## Resumo
- Reverte merge que aplicava layout com vermelho agressivo
- Restaura estilos originais em diversos componentes

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a69c8f1ff48322be05410adca2e922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Refreshed dark theme across app (bg-gray-900, text-gray-100) and toned-down red accents.
  * Removed heavy section borders; headings now bold with red-500.
  * Buttons updated to red→orange gradients with white text.
  * Inputs, cards, and tags use gray-800 backgrounds with simplified borders/focus.
  * Navbar adopts gray theme with streamlined hover states.
  * Particle colors softened for a subtler effect.
  * Progress bars and timelines updated to harmonized reds.
  * Removed Anton font/uppercase headings; switched to system fonts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->