### PR TITLE
Centraliza navbar e ajusta layout superior

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -41,7 +41,7 @@ function Home() {
     <section
       id="inicio"
       ref={ref}
-      className="relative min-h-screen flex items-center justify-center overflow-hidden px-4"
+      className="relative min-h-screen flex items-center justify-center overflow-hidden px-4 pt-16"
     >
       <div className="text-center z-10 space-y-4 sm:space-y-6">
         <h1 className="text-3xl md:text-5xl font-bold flex items-center justify-center gap-2 text-red-500">
@@ -72,7 +72,7 @@ function Home() {
         </div>
       </div>
       <span
-        className="shape absolute w-16 h-16 md:w-24 md:h-24 bg-red-600 opacity-10 md:opacity-20 left-10 top-10"
+        className="shape absolute w-16 h-16 md:w-24 md:h-24 bg-red-600 opacity-10 md:opacity-20 left-10 top-32"
         style={{ borderRadius: "20%" }}
       ></span>
       <span

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -16,7 +16,7 @@ function Navbar() {
 
   return (
     <nav className="fixed top-0 left-0 w-full bg-gray-900 z-50 text-gray-100 shadow">
-      <div className="max-w-5xl mx-auto flex items-center justify-end p-4">
+      <div className="max-w-5xl mx-auto flex items-center justify-end md:justify-center p-4">
         <button
           className="md:hidden"
           onClick={() => setAberto(true)}


### PR DESCRIPTION
## Resumo
- Centraliza itens da barra de navegação em telas maiores
- Ajusta o espaçamento da seção inicial e reposiciona forma decorativa

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a69e3018f483228508273c162bef4a