### PR TITLE
Reescreve comunicações públicas em primeira pessoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfólio CMS
 
-Aplicação completa (Spring Boot + React) para gerenciar o portfólio pessoal de David Henrique Miranda da Silva. O sistema possui uma área pública com informações sobre o profissional, lista de projetos, habilidades e contato, além de um painel administrativo protegido por JWT para cadastro e edição de conteúdo.
+Criei esta aplicação completa (Spring Boot + React) para gerenciar meu portfólio profissional. Organizei uma área pública com minhas informações, projetos, habilidades e contatos, além de um painel administrativo protegido por JWT onde controlo todo o conteúdo.
 
 ## ✨ Tecnologias
 
@@ -32,16 +32,16 @@ Aplicação completa (Spring Boot + React) para gerenciar o portfólio pessoal d
 - Java 17+
 - Maven 3.9+
 - Node.js 18+
-- PostgreSQL 15 (ou usar Docker)
+- PostgreSQL 15 (ou Docker)
 
 ### Backend
 ```bash
 cd backend
 mvn spring-boot:run
 ```
-A API estará disponível em `http://localhost:8080`.
+Eu disponibilizo a API em `http://localhost:8080`.
 
-Credenciais padrão do administrador (configuradas via Flyway):
+Credenciais padrão do administrador (definidas via Flyway):
 - **Usuário:** `admin`
 - **Senha:** `admin123`
 
@@ -51,19 +51,19 @@ cd frontend
 npm install
 npm run dev
 ```
-A aplicação web ficará disponível em `http://localhost:5173`.
+Eu acesso a aplicação web em `http://localhost:5173`.
 
 ## 🐳 Executando com Docker Compose
 ```bash
 docker compose up --build
 ```
-Serviços expostos:
+Os serviços sobem da seguinte forma:
 - Frontend: http://localhost:5173
 - Backend: http://localhost:8080
 - PostgreSQL: localhost:5432 (user/database/password: `portfolio`)
 
 ## 📚 Documentação da API
-Acesse `http://localhost:8080/swagger-ui/index.html` para visualizar e testar os endpoints. Utilize o botão `Authorize` e informe `Bearer {token}` após realizar login.
+Disponibilizei o Swagger em `http://localhost:8080/swagger-ui/index.html`. Após fazer login, basta clicar em `Authorize` e informar `Bearer {token}` para testar os endpoints.
 
 ## 📂 Uploads de imagem
-As imagens enviadas pelo painel administrativo são salvas no diretório `uploads/` (mapeado em volume Docker) e servidas pela API através do caminho `/uploads/{arquivo}`.
+Guardo as imagens enviadas pelo painel no diretório `uploads/` (mapeado como volume Docker) e sirvo cada arquivo pela API no caminho `/uploads/{arquivo}`.

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -3,7 +3,7 @@ function Footer() {
     <footer className="border-t border-slate-800 bg-slate-900/50">
       <div className="max-w-6xl mx-auto px-4 py-6 text-sm text-slate-400 flex flex-col md:flex-row justify-between items-center gap-2">
         <span>© {new Date().getFullYear()} David Henrique Miranda da Silva</span>
-        <span>Construído com Spring Boot &amp; React.</span>
+        <span>Construí esta plataforma com Spring Boot &amp; React.</span>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- rewrite the README introduction and usage instructions so they sound like they were authored in first person
- adjust the site footer copy to a first-person tone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e1d9ff7ab48320b4f93ac2c579b26f