### PR TITLE
Add demo fallbacks for public pages when API data missing

### DIFF
--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -1,17 +1,21 @@
 import { useEffect, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
+import { fallbackProfile } from '../utils/fallbackData.js';
 
 function ContactPage() {
   const [profile, setProfile] = useState(null);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     async function loadProfile() {
       try {
         const { data } = await api.get('/api/public/profile');
-        setProfile(data);
+        setProfile(data ?? null);
       } catch (error) {
         console.error('Erro ao carregar perfil', error);
+        setProfile(fallbackProfile);
+        setLoadError(true);
       }
     }
     loadProfile();
@@ -27,6 +31,11 @@ function ContactPage() {
       <p className="text-slate-300">
         Estou sempre aberto a novas oportunidades, desafios interessantes e bate-papos sobre tecnologia.
       </p>
+      {loadError && (
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+          Mostrando dados de contato de demonstração.
+        </p>
+      )}
       <div className="space-y-4">
         {profile.email && (
           <a

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,12 +1,30 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
+import { fallbackProfile, fallbackProjects } from '../utils/fallbackData.js';
 
 function HomePage() {
   const [profile, setProfile] = useState(null);
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  const displayProfile = useMemo(() => profile ?? fallbackProfile, [profile]);
+  const displayProjects = useMemo(() => (projects.length > 0 ? projects : fallbackProjects), [projects]);
+  const profileInitials = useMemo(() => {
+    if (displayProfile.photoUrl) {
+      return '';
+    }
+    if (displayProfile.initials) {
+      return displayProfile.initials;
+    }
+    if (!displayProfile.fullName) {
+      return '??';
+    }
+    const [first = '', second = ''] = displayProfile.fullName.trim().split(' ');
+    return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
+  }, [displayProfile]);
 
   useEffect(() => {
     async function loadData() {
@@ -15,10 +33,11 @@ function HomePage() {
           api.get('/api/public/profile'),
           api.get('/api/public/projects')
         ]);
-        setProfile(profileResponse.data);
-        setProjects(projectsResponse.data.slice(0, 3));
+        setProfile(profileResponse.data ?? null);
+        setProjects(Array.isArray(projectsResponse.data) ? projectsResponse.data.slice(0, 3) : []);
       } catch (error) {
         console.error('Erro ao carregar dados', error);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -30,43 +49,50 @@ function HomePage() {
     return <p className="text-center text-slate-400">Carregando...</p>;
   }
 
-  if (!profile) {
-    return <p className="text-center text-slate-400">Perfil não configurado ainda.</p>;
-  }
-
   return (
     <div className="space-y-16">
       <section className="flex flex-col md:flex-row items-center gap-10">
-        <img
-          src={profile.photoUrl}
-          alt={profile.fullName}
-          className="w-40 h-40 rounded-full object-cover border-4 border-primary-500 shadow-lg"
-        />
+        {displayProfile.photoUrl ? (
+          <img
+            src={displayProfile.photoUrl}
+            alt={displayProfile.fullName}
+            className="w-40 h-40 rounded-full object-cover border-4 border-primary-500 shadow-lg"
+          />
+        ) : (
+          <div className="w-40 h-40 rounded-full border-4 border-primary-500 shadow-lg bg-primary-500/20 flex items-center justify-center">
+            <span className="text-3xl font-semibold text-primary-200">{profileInitials}</span>
+          </div>
+        )}
         <div className="space-y-4">
           <p className="uppercase text-xs tracking-[0.35em] text-primary-500">Bem-vindo</p>
-          <h1 className="text-4xl md:text-5xl font-bold text-white">{profile.fullName}</h1>
-          <p className="text-lg text-slate-300">{profile.role}</p>
-          <p className="text-slate-400 max-w-2xl">{profile.bio}</p>
+          <h1 className="text-4xl md:text-5xl font-bold text-white">{displayProfile.fullName}</h1>
+          <p className="text-lg text-slate-300">{displayProfile.role}</p>
+          <p className="text-slate-400 max-w-2xl">{displayProfile.bio}</p>
           <div className="flex flex-wrap gap-4 text-sm text-slate-300">
-            {profile.githubUrl && (
-              <a href={profile.githubUrl} target="_blank" rel="noreferrer">
+            {displayProfile.githubUrl && (
+              <a href={displayProfile.githubUrl} target="_blank" rel="noreferrer">
                 GitHub
               </a>
             )}
-            {profile.linkedinUrl && (
-              <a href={profile.linkedinUrl} target="_blank" rel="noreferrer">
+            {displayProfile.linkedinUrl && (
+              <a href={displayProfile.linkedinUrl} target="_blank" rel="noreferrer">
                 LinkedIn
               </a>
             )}
-            {profile.email && <a href={`mailto:${profile.email}`}>Email</a>}
+            {displayProfile.email && <a href={`mailto:${displayProfile.email}`}>Email</a>}
           </div>
+          {loadError && (
+            <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+              Mostrando conteúdo de demonstração. Configure o backend para ver seus dados reais.
+            </p>
+          )}
         </div>
       </section>
 
       <section className="space-y-6">
         <SectionTitle title="Habilidades" subtitle="Skills" />
         <div className="flex flex-wrap gap-3">
-          {profile.skills?.map((skill) => (
+          {displayProfile.skills?.map((skill) => (
             <span key={skill} className="px-4 py-2 rounded-full bg-slate-900 border border-slate-800 text-sm">
               {skill}
             </span>
@@ -77,7 +103,7 @@ function HomePage() {
       <section className="space-y-6">
         <SectionTitle title="Projetos em destaque" subtitle="Projetos" />
         <div className="grid md:grid-cols-3 gap-6">
-          {projects.map((project) => (
+          {displayProjects.map((project) => (
             <ProjectCard key={project.id} project={project} />
           ))}
         </div>

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -1,19 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
+import { fallbackProjects } from '../utils/fallbackData.js';
 
 function ProjectsPage() {
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  const hasProjects = projects.length > 0;
+  const displayProjects = useMemo(() => (hasProjects ? projects : fallbackProjects), [hasProjects, projects]);
+  const shouldShowGrid = hasProjects || loadError;
 
   useEffect(() => {
     async function loadProjects() {
       try {
         const { data } = await api.get('/api/public/projects');
-        setProjects(data);
+        setProjects(Array.isArray(data) ? data : []);
       } catch (error) {
         console.error('Erro ao carregar projetos', error);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -28,14 +35,21 @@ function ProjectsPage() {
   return (
     <div className="space-y-6">
       <SectionTitle title="Projetos" subtitle="Portfólio" />
-      {projects.length === 0 ? (
-        <p className="text-slate-400">Nenhum projeto publicado até o momento.</p>
-      ) : (
-        <div className="grid md:grid-cols-3 gap-6">
-          {projects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
-          ))}
+      {shouldShowGrid ? (
+        <div className="space-y-4">
+          {loadError && (
+            <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+              Mostrando projetos de demonstração.
+            </p>
+          )}
+          <div className="grid md:grid-cols-3 gap-6">
+            {displayProjects.map((project) => (
+              <ProjectCard key={project.id} project={project} />
+            ))}
+          </div>
         </div>
+      ) : (
+        <p className="text-slate-400">Nenhum projeto publicado até o momento.</p>
       )}
     </div>
   );

--- a/frontend/src/utils/fallbackData.js
+++ b/frontend/src/utils/fallbackData.js
@@ -1,0 +1,40 @@
+export const fallbackProfile = {
+  fullName: 'Seu nome incrível',
+  initials: 'SN',
+  role: 'Desenvolvedor(a) Full Stack',
+  bio: 'Conecte sua API para apresentar seu portfólio completo. Enquanto isso, mostramos um exemplo de como suas informações aparecerão.',
+  skills: ['React', 'Node.js', 'TypeScript', 'Tailwind CSS'],
+  githubUrl: 'https://github.com',
+  linkedinUrl: 'https://www.linkedin.com',
+  email: 'voce@exemplo.com'
+};
+
+export const fallbackProjects = [
+  {
+    id: 'demo-1',
+    title: 'Dashboard interativo',
+    description:
+      'Um painel responsivo construído com React e Tailwind, perfeito para acompanhar métricas importantes de produtos digitais.',
+    imageUrl: null,
+    projectUrl: null,
+    repositoryUrl: null
+  },
+  {
+    id: 'demo-2',
+    title: 'API de portfólio',
+    description:
+      'Serviço REST em Spring Boot com endpoints para gerenciar projetos, habilidades e perfis profissionais.',
+    imageUrl: null,
+    projectUrl: null,
+    repositoryUrl: null
+  },
+  {
+    id: 'demo-3',
+    title: 'Landing page moderna',
+    description:
+      'Página institucional otimizada para SEO e performance, destacando produtos e depoimentos com design elegante.',
+    imageUrl: null,
+    projectUrl: null,
+    repositoryUrl: null
+  }
+];


### PR DESCRIPTION
## Summary
- add shared fallback profile and project data for the public experience
- update the home, projects, and contact pages to surface demo content and guard against empty API responses
- show visual placeholders and messaging when demo data is being displayed
