### PR TITLE
Remove fallback project cards

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
-import { fallbackProfile, fallbackProjects } from '../utils/fallbackData.js';
+import { fallbackProfile } from '../utils/fallbackData.js';
 
 function HomePage() {
   const [profile, setProfile] = useState(null);
@@ -11,7 +11,7 @@ function HomePage() {
   const [loadError, setLoadError] = useState(false);
 
   const displayProfile = useMemo(() => profile ?? fallbackProfile, [profile]);
-  const displayProjects = useMemo(() => (projects.length > 0 ? projects : fallbackProjects), [projects]);
+  const hasProjects = projects.length > 0;
   const profileInitials = useMemo(() => {
     if (displayProfile.photoUrl) {
       return '';
@@ -102,11 +102,17 @@ function HomePage() {
 
       <section className="space-y-6">
         <SectionTitle title="Projetos em destaque" subtitle="Projetos" />
-        <div className="grid md:grid-cols-3 gap-6">
-          {displayProjects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
-          ))}
-        </div>
+        {hasProjects ? (
+          <div className="grid md:grid-cols-3 gap-6">
+            {projects.map((project) => (
+              <ProjectCard key={project.id} project={project} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-slate-400">
+            {loadError ? 'Não foi possível carregar os projetos agora.' : 'Nenhum projeto disponível no momento.'}
+          </p>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
-import { fallbackProjects } from '../utils/fallbackData.js';
 
 function ProjectsPage() {
   const [projects, setProjects] = useState([]);
@@ -10,8 +9,6 @@ function ProjectsPage() {
   const [loadError, setLoadError] = useState(false);
 
   const hasProjects = projects.length > 0;
-  const displayProjects = useMemo(() => (hasProjects ? projects : fallbackProjects), [hasProjects, projects]);
-  const shouldShowGrid = hasProjects || loadError;
 
   useEffect(() => {
     async function loadProjects() {
@@ -35,21 +32,16 @@ function ProjectsPage() {
   return (
     <div className="space-y-6">
       <SectionTitle title="Projetos" subtitle="Portfólio" />
-      {shouldShowGrid ? (
-        <div className="space-y-4">
-          {loadError && (
-            <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
-              Mostrando projetos de demonstração.
-            </p>
-          )}
-          <div className="grid md:grid-cols-3 gap-6">
-            {displayProjects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
-            ))}
-          </div>
+      {hasProjects ? (
+        <div className="grid md:grid-cols-3 gap-6">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
         </div>
       ) : (
-        <p className="text-slate-400">Nenhum projeto publicado até o momento.</p>
+        <p className="text-slate-400">
+          {loadError ? 'Não foi possível carregar os projetos agora.' : 'Nenhum projeto publicado até o momento.'}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/utils/fallbackData.js
+++ b/frontend/src/utils/fallbackData.js
@@ -9,32 +9,4 @@ export const fallbackProfile = {
   email: 'voce@exemplo.com'
 };
 
-export const fallbackProjects = [
-  {
-    id: 'demo-1',
-    title: 'Dashboard interativo',
-    description:
-      'Um painel responsivo construído com React e Tailwind, perfeito para acompanhar métricas importantes de produtos digitais.',
-    imageUrl: null,
-    projectUrl: null,
-    repositoryUrl: null
-  },
-  {
-    id: 'demo-2',
-    title: 'API de portfólio',
-    description:
-      'Serviço REST em Spring Boot com endpoints para gerenciar projetos, habilidades e perfis profissionais.',
-    imageUrl: null,
-    projectUrl: null,
-    repositoryUrl: null
-  },
-  {
-    id: 'demo-3',
-    title: 'Landing page moderna',
-    description:
-      'Página institucional otimizada para SEO e performance, destacando produtos e depoimentos com design elegante.',
-    imageUrl: null,
-    projectUrl: null,
-    repositoryUrl: null
-  }
-];
+export const fallbackProjects = [];


### PR DESCRIPTION
## Summary
- remove the hardcoded fallback project cards from the portfolio pages
- show status messages when there are no projects or when the API cannot be reached
