### PR TITLE
Add demo project fallback data for offline portfolio view

### DIFF
--- a/frontend/src/components/ProjectCard.jsx
+++ b/frontend/src/components/ProjectCard.jsx
@@ -20,9 +20,11 @@ function ProjectCard({ project }) {
               Repositório
             </a>
           )}
-          <Link to={`/projects/${project.id}`} className="ml-auto text-slate-300 hover:text-white">
-            Detalhes
-          </Link>
+          {project.id && (
+            <Link to={`/projects/${project.id}`} className="ml-auto text-slate-300 hover:text-white">
+              Detalhes
+            </Link>
+          )}
         </div>
       </div>
     </article>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,13 +2,14 @@ import { useEffect, useMemo, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
-import { fallbackProfile } from '../utils/fallbackData.js';
+import { fallbackProfile, fallbackProjects } from '../utils/fallbackData.js';
 
 function HomePage() {
   const [profile, setProfile] = useState(null);
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [usingFallbackProjects, setUsingFallbackProjects] = useState(false);
 
   const displayProfile = useMemo(() => {
     if (!profile) {
@@ -77,9 +78,13 @@ function HomePage() {
         ]);
         setProfile(profileResponse.data ?? null);
         setProjects(Array.isArray(projectsResponse.data) ? projectsResponse.data.slice(0, 3) : []);
+        setLoadError(false);
+        setUsingFallbackProjects(false);
       } catch (error) {
         console.error('Erro ao carregar dados', error);
         setLoadError(true);
+        setProjects(fallbackProjects.slice(0, 3));
+        setUsingFallbackProjects(true);
       } finally {
         setLoading(false);
       }
@@ -144,6 +149,11 @@ function HomePage() {
 
       <section className="space-y-6">
         <SectionTitle title="Projetos em destaque" subtitle="Projetos" />
+        {usingFallbackProjects && (
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+            Mostrando projetos de demonstração. Conecte o backend para ver seus projetos reais.
+          </p>
+        )}
         {hasProjects ? (
           <div className="grid md:grid-cols-3 gap-6">
             {projects.map((project) => (

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react';
 import api from '../api/client.js';
 import SectionTitle from '../components/SectionTitle.jsx';
 import ProjectCard from '../components/ProjectCard.jsx';
+import { fallbackProjects } from '../utils/fallbackData.js';
 
 function ProjectsPage() {
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [usingFallbackProjects, setUsingFallbackProjects] = useState(false);
 
   const hasProjects = projects.length > 0;
 
@@ -15,9 +17,13 @@ function ProjectsPage() {
       try {
         const { data } = await api.get('/api/public/projects');
         setProjects(Array.isArray(data) ? data : []);
+        setLoadError(false);
+        setUsingFallbackProjects(false);
       } catch (error) {
         console.error('Erro ao carregar projetos', error);
         setLoadError(true);
+        setProjects(fallbackProjects);
+        setUsingFallbackProjects(true);
       } finally {
         setLoading(false);
       }
@@ -32,6 +38,11 @@ function ProjectsPage() {
   return (
     <div className="space-y-6">
       <SectionTitle title="Projetos" subtitle="Portfólio" />
+      {usingFallbackProjects && (
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+          Mostrando projetos de demonstração. Configure o backend para listar seus projetos reais.
+        </p>
+      )}
       {hasProjects ? (
         <div className="grid md:grid-cols-3 gap-6">
           {projects.map((project) => (

--- a/frontend/src/utils/fallbackData.js
+++ b/frontend/src/utils/fallbackData.js
@@ -9,4 +9,32 @@ export const fallbackProfile = {
   email: 'voce@exemplo.com'
 };
 
-export const fallbackProjects = [];
+export const fallbackProjects = [
+  {
+    id: null,
+    title: 'Dashboard de Analytics',
+    description:
+      'Painel completo construído com React, Tailwind CSS e integração com APIs externas para acompanhar métricas de produtos em tempo real.',
+    imageUrl: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80',
+    projectUrl: 'https://github.com',
+    repositoryUrl: 'https://github.com'
+  },
+  {
+    id: null,
+    title: 'API de Portfólio',
+    description:
+      'Serviço REST com Spring Boot, autenticação JWT e PostgreSQL para gerenciar projetos, habilidades e perfil profissional.',
+    imageUrl: 'https://images.unsplash.com/photo-1555949963-aa79dcee981c?auto=format&fit=crop&w=800&q=80',
+    projectUrl: 'https://github.com',
+    repositoryUrl: 'https://github.com'
+  },
+  {
+    id: null,
+    title: 'Landing Page Responsiva',
+    description:
+      'Single Page Application otimizada para SEO, com foco em performance e acessibilidade utilizando Vite e animações sutis.',
+    imageUrl: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80',
+    projectUrl: 'https://github.com',
+    repositoryUrl: 'https://github.com'
+  }
+];


### PR DESCRIPTION
## Summary
- add sample fallback projects that illustrate portfolio content when the API is offline
- surface the fallback projects and explanatory messaging on the home and projects pages
- hide the details link for demo cards to avoid navigation to missing resources
