### PR TITLE
Add public health check endpoints

### DIFF
--- a/backend/src/main/java/com/portfoliocms/config/SecurityConfig.java
+++ b/backend/src/main/java/com/portfoliocms/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/public/**", "/v3/api-docs/**", "/swagger-ui/**", "/uploads/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/public/**", "/api/health/**", "/v3/api-docs/**", "/swagger-ui/**", "/uploads/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(daoAuthenticationProvider())

--- a/backend/src/main/java/com/portfoliocms/controller/HealthController.java
+++ b/backend/src/main/java/com/portfoliocms/controller/HealthController.java
@@ -1,0 +1,34 @@
+package com.portfoliocms.controller;
+
+import com.portfoliocms.dto.HealthEchoRequest;
+import com.portfoliocms.dto.HealthEchoResponse;
+import com.portfoliocms.dto.HealthStatusResponse;
+import com.portfoliocms.service.HealthService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/health")
+public class HealthController {
+
+    private final HealthService healthService;
+
+    public HealthController(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @GetMapping
+    public HealthStatusResponse healthStatus() {
+        return healthService.getHealthStatus();
+    }
+
+    @PostMapping("/ping")
+    public HealthEchoResponse echo(@RequestBody(required = false) HealthEchoRequest request) {
+        String message = request != null ? request.getMessage() : null;
+        return healthService.echo(message);
+    }
+}
+

--- a/backend/src/main/java/com/portfoliocms/dto/HealthEchoRequest.java
+++ b/backend/src/main/java/com/portfoliocms/dto/HealthEchoRequest.java
@@ -1,0 +1,22 @@
+package com.portfoliocms.dto;
+
+public class HealthEchoRequest {
+
+    private String message;
+
+    public HealthEchoRequest() {
+    }
+
+    public HealthEchoRequest(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}
+

--- a/backend/src/main/java/com/portfoliocms/dto/HealthEchoResponse.java
+++ b/backend/src/main/java/com/portfoliocms/dto/HealthEchoResponse.java
@@ -1,0 +1,41 @@
+package com.portfoliocms.dto;
+
+import java.time.OffsetDateTime;
+
+public class HealthEchoResponse {
+
+    private String status;
+    private String receivedMessage;
+    private OffsetDateTime timestamp;
+
+    public HealthEchoResponse(String status, String receivedMessage, OffsetDateTime timestamp) {
+        this.status = status;
+        this.receivedMessage = receivedMessage;
+        this.timestamp = timestamp;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getReceivedMessage() {
+        return receivedMessage;
+    }
+
+    public void setReceivedMessage(String receivedMessage) {
+        this.receivedMessage = receivedMessage;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(OffsetDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}
+

--- a/backend/src/main/java/com/portfoliocms/dto/HealthStatusResponse.java
+++ b/backend/src/main/java/com/portfoliocms/dto/HealthStatusResponse.java
@@ -1,0 +1,66 @@
+package com.portfoliocms.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class HealthStatusResponse {
+
+    private String status;
+    private String application;
+    private OffsetDateTime timestamp;
+    private long uptimeMillis;
+    private List<String> availableEndpoints;
+
+    public HealthStatusResponse(String status,
+                                String application,
+                                OffsetDateTime timestamp,
+                                long uptimeMillis,
+                                List<String> availableEndpoints) {
+        this.status = status;
+        this.application = application;
+        this.timestamp = timestamp;
+        this.uptimeMillis = uptimeMillis;
+        this.availableEndpoints = availableEndpoints;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(OffsetDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getUptimeMillis() {
+        return uptimeMillis;
+    }
+
+    public void setUptimeMillis(long uptimeMillis) {
+        this.uptimeMillis = uptimeMillis;
+    }
+
+    public List<String> getAvailableEndpoints() {
+        return availableEndpoints;
+    }
+
+    public void setAvailableEndpoints(List<String> availableEndpoints) {
+        this.availableEndpoints = availableEndpoints;
+    }
+}
+

--- a/backend/src/main/java/com/portfoliocms/service/HealthService.java
+++ b/backend/src/main/java/com/portfoliocms/service/HealthService.java
@@ -1,0 +1,42 @@
+package com.portfoliocms.service;
+
+import com.portfoliocms.dto.HealthEchoResponse;
+import com.portfoliocms.dto.HealthStatusResponse;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+public class HealthService {
+
+    private final Instant startedAt;
+
+    public HealthService() {
+        this.startedAt = Instant.now();
+    }
+
+    public HealthStatusResponse getHealthStatus() {
+        long uptimeMillis = Duration.between(startedAt, Instant.now()).toMillis();
+        return new HealthStatusResponse(
+                "UP",
+                "Portfolio CMS API",
+                OffsetDateTime.now(ZoneOffset.UTC),
+                uptimeMillis,
+                List.of("GET /api/health", "POST /api/health/ping")
+        );
+    }
+
+    public HealthEchoResponse echo(String message) {
+        String sanitizedMessage = message != null ? message : "";
+        return new HealthEchoResponse(
+                "ACK",
+                sanitizedMessage,
+                OffsetDateTime.now(ZoneOffset.UTC)
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated HealthController with GET and POST endpoints under /api/health
- provide structured health and echo responses backed by a new HealthService and DTOs
- expose the health endpoints without authentication via the security configuration
