### PR TITLE
Add request logging filter and automated run script with reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ mvn clean package
 java -jar target/portifolio-*.jar
 ```
 
+#### Backend com relatório automático de requisições
+Para iniciar o backend já capturando um log detalhado de todas as requisições (método, rota, status, tempo de resposta e payloads), execute o script na raiz do projeto:
+
+```bash
+./scripts/run_with_logging.py
+```
+
+O script cria um arquivo de log completo e, ao finalizar (inclusive com `Ctrl+C`), gera automaticamente um relatório `.txt` em `logs/` com os totais por método, códigos de status, endpoints mais acessados, requisições mais lentas e últimos erros registrados.
+
 ### Frontend
 ```bash
 cd frontend

--- a/backend/src/main/java/com/portfoliocms/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/com/portfoliocms/logging/HttpLoggingFilter.java
@@ -1,0 +1,183 @@
+package com.portfoliocms.logging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Component
+public class HttpLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpLoggingFilter.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int MAX_PAYLOAD_LENGTH = 2048;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (isAsyncDispatch(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        ContentCachingRequestWrapper wrappedRequest = wrapRequest(request);
+        ContentCachingResponseWrapper wrappedResponse = wrapResponse(response);
+        long startTime = System.currentTimeMillis();
+
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse);
+        } catch (Exception ex) {
+            LOGGER.error("Exceção durante o processamento da requisição", ex);
+            throw ex;
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            Map<String, Object> payload = buildPayload(wrappedRequest, wrappedResponse, duration);
+            logPayload(payload);
+            wrappedResponse.copyBodyToResponse();
+        }
+    }
+
+    private void logPayload(Map<String, Object> payload) {
+        try {
+            LOGGER.info("HTTP {}", OBJECT_MAPPER.writeValueAsString(payload));
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Não foi possível serializar o relatório da requisição", e);
+        }
+    }
+
+    private Map<String, Object> buildPayload(ContentCachingRequestWrapper request,
+                                             ContentCachingResponseWrapper response,
+                                             long duration) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("timestamp", Instant.now().toString());
+        payload.put("method", request.getMethod());
+        payload.put("path", request.getRequestURI());
+        payload.put("query", emptyToNull(request.getQueryString()));
+        payload.put("status", response.getStatus());
+        payload.put("durationMs", duration);
+        payload.put("ip", request.getRemoteAddr());
+        payload.put("requestHeaders", extractRequestHeaders(request));
+        payload.put("responseHeaders", extractResponseHeaders(response));
+        payload.put("requestBody", readPayload(request.getContentAsByteArray(), request.getCharacterEncoding()));
+        payload.put("responseBody", readPayload(response.getContentAsByteArray(), response.getCharacterEncoding()));
+        return payload;
+    }
+
+    private Map<String, List<String>> extractRequestHeaders(ContentCachingRequestWrapper request) {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        List<String> headerNames = Collections.list(request.getHeaderNames());
+        for (String headerName : headerNames) {
+            List<String> values = Collections.list(request.getHeaders(headerName));
+            headers.put(headerName, sanitizeHeaderValues(headerName, values));
+        }
+        return headers;
+    }
+
+    private Map<String, List<String>> extractResponseHeaders(ContentCachingResponseWrapper response) {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (String headerName : response.getHeaderNames()) {
+            headers.put(headerName, new LinkedList<>(response.getHeaders(headerName)));
+        }
+        return headers;
+    }
+
+    private ContentCachingRequestWrapper wrapRequest(HttpServletRequest request) {
+        if (request instanceof ContentCachingRequestWrapper cachingRequest) {
+            return cachingRequest;
+        }
+        return new ContentCachingRequestWrapper(request);
+    }
+
+    private ContentCachingResponseWrapper wrapResponse(HttpServletResponse response) {
+        if (response instanceof ContentCachingResponseWrapper cachingResponse) {
+            return cachingResponse;
+        }
+        return new ContentCachingResponseWrapper(response);
+    }
+
+    private String readPayload(byte[] buffer, String characterEncoding) {
+        if (buffer == null || buffer.length == 0) {
+            return null;
+        }
+        if (isBinary(buffer)) {
+            return String.format(Locale.ROOT, "<conteúdo binário (%d bytes)>", buffer.length);
+        }
+
+        Charset charset = getCharset(characterEncoding);
+        int length = Math.min(buffer.length, MAX_PAYLOAD_LENGTH);
+        String payload = new String(buffer, 0, length, charset);
+        if (buffer.length > MAX_PAYLOAD_LENGTH) {
+            return payload + "… (truncado)";
+        }
+        return payload;
+    }
+
+    private Charset getCharset(String characterEncoding) {
+        if (characterEncoding == null || characterEncoding.isBlank()) {
+            return StandardCharsets.UTF_8;
+        }
+        try {
+            return Charset.forName(characterEncoding);
+        } catch (Exception ex) {
+            LOGGER.debug("Charset inválido '{}', usando UTF-8", characterEncoding, ex);
+            return StandardCharsets.UTF_8;
+        }
+    }
+
+    private boolean isBinary(byte[] buffer) {
+        for (byte b : buffer) {
+            int value = b & 0xFF;
+            if (value == 0) {
+                return true;
+            }
+            if (value < 0x09) {
+                return true;
+            }
+            if (value > 0x7E && value < 0xA0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> sanitizeHeaderValues(String headerName, List<String> values) {
+        if (values.isEmpty()) {
+            return values;
+        }
+        String normalized = headerName.toLowerCase(Locale.ROOT);
+        if (normalized.equals("authorization") || normalized.equals("proxy-authorization")) {
+            return Collections.singletonList("<oculto>");
+        }
+        if (normalized.equals("cookie") || normalized.equals("set-cookie")) {
+            return Collections.singletonList("<oculto>");
+        }
+        return values;
+    }
+
+    private String emptyToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/scripts/run_with_logging.py
+++ b/scripts/run_with_logging.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Executa o backend com geração automática de relatório de requisições."""
+
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+LOG_DIR = PROJECT_ROOT / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def main() -> int:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_file = LOG_DIR / f"backend-{timestamp}.log"
+    report_file = LOG_DIR / f"backend-{timestamp}-summary.txt"
+
+    cmd = ["mvn", "-pl", "backend", "spring-boot:run"]
+    print(f"Iniciando backend com comando: {' '.join(cmd)}")
+    print(f"Logs completos serão salvos em: {log_file}")
+
+    process = subprocess.Popen(
+        cmd,
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+    if process.stdout is None:
+        raise RuntimeError("Não foi possível capturar a saída do processo do backend")
+
+    def _terminate(signum, frame):  # type: ignore[override]
+        if process.poll() is None:
+            print("\nSolicitando parada do backend...")
+            process.terminate()
+
+    signal.signal(signal.SIGINT, _terminate)
+    signal.signal(signal.SIGTERM, _terminate)
+
+    with log_file.open("w", encoding="utf-8") as log_handle:
+        try:
+            for line in iter(process.stdout.readline, ""):
+                print(line, end="")
+                log_handle.write(line)
+        except KeyboardInterrupt:
+            _terminate(signal.SIGINT, None)
+        finally:
+            process.wait()
+            if process.returncode not in (0, None):
+                print(f"Processo finalizado com código {process.returncode}")
+
+    generate_report(log_file, report_file)
+    print(f"Relatório resumido salvo em: {report_file}")
+    return process.returncode or 0
+
+
+def generate_report(log_path: Path, report_path: Path) -> None:
+    pattern = "HTTP "
+    method_counter: Counter[str] = Counter()
+    status_counter: Counter[str] = Counter()
+    family_counter: Counter[str] = Counter()
+    endpoint_counter: Counter[str] = Counter()
+    durations: List[Tuple[int, str, str, str]] = []
+    errors: List[str] = []
+
+    with log_path.open(encoding="utf-8") as log_handle:
+        for raw_line in log_handle:
+            line = raw_line.strip()
+            if " ERROR " in raw_line:
+                errors.append(line)
+            if pattern not in raw_line:
+                continue
+            payload = extract_payload(raw_line)
+            if payload is None:
+                continue
+            method = payload.get("method", "UNKNOWN")
+            path = payload.get("path", "-")
+            status_raw = payload.get("status", 0)
+            status = str(status_raw)
+            try:
+                status_code = int(status_raw)
+            except (TypeError, ValueError):
+                status_code = None
+            duration = payload.get("durationMs")
+
+            method_counter[method] += 1
+            status_counter[status] += 1
+            family = f"{status_code // 100}xx" if status_code is not None and status_code >= 100 else "desconhecido"
+            family_counter[family] += 1
+            endpoint_counter[path] += 1
+            if isinstance(duration, (int, float)):
+                durations.append((int(duration), method, path, status))
+
+    total_requests = sum(method_counter.values())
+
+    with report_path.open("w", encoding="utf-8") as report:
+        report.write("Resumo de requisições HTTP\n")
+        report.write("=" * 30 + "\n\n")
+        report.write(f"Arquivo de log: {log_path}\n")
+        report.write(f"Total de requisições: {total_requests}\n\n")
+
+        report.write("Por método:\n")
+        for method, count in method_counter.most_common():
+            report.write(f"  - {method}: {count}\n")
+        report.write("\n")
+
+        report.write("Por família de status:\n")
+        for family, count in family_counter.most_common():
+            report.write(f"  - {family}: {count}\n")
+        report.write("\n")
+
+        report.write("Status detalhados:\n")
+        for status, count in status_counter.most_common():
+            report.write(f"  - {status}: {count}\n")
+        report.write("\n")
+
+        report.write("Endpoints mais acessados:\n")
+        for path, count in endpoint_counter.most_common(10):
+            report.write(f"  - {path}: {count}\n")
+        report.write("\n")
+
+        if durations:
+            average = sum(d for d, *_ in durations) / len(durations)
+            slowest = sorted(durations, key=lambda item: item[0], reverse=True)[:5]
+            report.write(f"Tempo médio: {average:.2f} ms\n")
+            report.write("Top 5 requisições mais lentas:\n")
+            for duration, method, path, status in slowest:
+                report.write(f"  - {method} {path} ({status}) -> {duration} ms\n")
+            report.write("\n")
+
+        if errors:
+            report.write("Últimas mensagens de erro:\n")
+            for entry in errors[-20:]:
+                report.write(f"  - {entry}\n")
+            report.write("\n")
+
+        report.write("Fim do relatório.\n")
+
+
+def extract_payload(line: str) -> Dict[str, object] | None:
+    try:
+        _, json_part = line.split("HTTP ", 1)
+        json_part = json_part.strip()
+        return json.loads(json_part)
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("Execução interrompida pelo usuário.")
+        sys.exit(130)


### PR DESCRIPTION
## Summary
- add a Spring filter that records each HTTP request/response with sanitized headers and bounded payloads in JSON-formatted logs
- provide a Python helper script that starts the backend, stores the log output, and generates a summary report when stopped with Ctrl+C
- document how to run the backend with the new logging/reporting workflow in the README
