### PR TITLE
Add Flyway Postgres extension for future compatibility

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,6 +20,7 @@
     <properties>
         <java.version>17</java.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <flyway.version>10.10.0</flyway.version>
     </properties>
 
     <dependencies>
@@ -42,6 +43,12 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${flyway.version}</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
## Summary
- pin the Flyway dependency version
- add the Flyway PostgreSQL extension so newer PostgreSQL releases remain supported

## Testing
- not run (network access required to download Maven dependencies)

------
https://chatgpt.com/codex/tasks/task_b_68e1f59e2f8883208cd2e54f2f126324